### PR TITLE
reference category data file for shortlists

### DIFF
--- a/_includes/post-attributes.html
+++ b/_includes/post-attributes.html
@@ -88,7 +88,7 @@
   </div>
   <div class="attribute-section">
     <strong class="attribute-section-title">Category</strong>
-    {{page.category}}
+    {{ site.data.categories[page.category].name }}
   </div>
 </div>
 {% endif %}

--- a/_includes/shortlist-list.html
+++ b/_includes/shortlist-list.html
@@ -16,7 +16,7 @@
       </li>
       {% for category in categories %}
         <li>
-          <a href="#" id="{{ category | slugify }}">{{ category }}</a>
+          <a href="#" id="{{ category | slugify }}">{{ site.data.categories[category].name }}</a>
         </li>
       {% endfor %}
     </ul>
@@ -29,7 +29,7 @@
          data-tag="{{- category | slugify -}}">
       <div class="project-details">
         <div class="project-category">
-          {{ project.category }}
+          {{ site.data.categories[project.category].name }}
         </div>
         <div class="project-title">
           <a href="{{ site.url }}{{ project.url }}">{{ project.title }}</a>


### PR DESCRIPTION
Initially, we were displaying the string form the shortlist.md file on our project shortlist list and shortlist posts. This will now display reference the data/categories.yml as intended.