### PR TITLE
Update "Careers" link and add azavea.com link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output
+
+Closes #XXX

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,7 +41,7 @@
           <li><a href="https://www.azavea.com/about/">About</a></li>
           <li><a href="https://www.azavea.com/work/">What we do</a></li>
           <li><a href="https://www.azavea.com/research/">Research</a></li>
-          <li><a href="http://jobs.azavea.com/">Jobs</a></li>
+          <li><a href="https://careers.azavea.com/">Careers</a></li>
           <li><a href="https://www.azavea.com/blog/">Blog</a></li>
           <li><a href="https://www.azavea.com/press/">Press</a></li>
         </ul>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -40,5 +40,8 @@
         {% endif %}
       </nav>
     </div>
+    <a href="https://www.azavea.com" class="azavea-link" title="Azavea homepage">
+      Go to azavea.com
+    </a>
   </div>
 </div>

--- a/_sass/layout/_navbar.scss
+++ b/_sass/layout/_navbar.scss
@@ -3,7 +3,7 @@
   position: absolute;
   z-index: 100;
   width: 100%;
-  padding: 2rem;
+  padding: 3rem 2rem 2rem;
   left: 0;
   top: 1rem;
 
@@ -15,6 +15,7 @@
   .container {
     display: flex;
     max-width: 1190px;
+    position: relative;
 
     @include respond-to('xs') {
       flex-direction: column;
@@ -103,6 +104,11 @@
 
 .navbar-left {
   flex: 1;
+
+  @include respond-to('xs') {
+    text-align: left;
+    padding-left: 2.5rem;
+  }
 }
 
 .navbar-right {
@@ -135,4 +141,30 @@
   transform: scale(0.9);
   transform-origin: right;
   margin-top: 5px;
+}
+
+.azavea-link {
+  font-size: $a-font-size;
+  font-weight: $a-font-weight;
+  color: $a-link-color;
+  background: $a-link-background;
+  padding: 1rem 2rem 1rem;
+  border-radius: 0 0 4px 4px;
+  right: 2rem;
+  top: -4rem;
+  line-height: 1;
+  box-shadow: 0 0 10px $a-box-shadow-color;
+  position: absolute;
+
+  @include respond-to('xs') {
+    top: -5px;
+    margin-right: 2.5rem;
+    right: 0;
+  }
+
+  &:hover {
+    color: $primary;
+    cursor: pointer;
+    text-decoration: underline;
+  }
 }

--- a/_sass/settings/_colors.scss
+++ b/_sass/settings/_colors.scss
@@ -14,3 +14,15 @@ $white: #fff;
 $off-white: #ebf0f5;
 
 $red: #d84d47;
+
+
+/**
+ * Grayscale
+ */
+$brand-ink: #27323D;
+$brand-granite: #4D6379;
+$brand-slate: #7C94AC;
+$brand-pewter: #B8C5D2;
+$brand-steel: #D0D9E1;
+$brand-porcelain: #E5EAEE;
+$brand-off-white: #F4F6F8;

--- a/_sass/settings/_variables.scss
+++ b/_sass/settings/_variables.scss
@@ -36,3 +36,10 @@ $focus-state: 0 0 0 3px rgba(lighten($primary, 10%), .4);
  * Shadows
  * * * */
 $shadow-default: 0 24px 32px rgba($black, .1);
+
+// Go to Azavea Navbar link:
+$a-font-size: 1.25rem;
+$a-font-weight: 400;
+$a-link-background: $brand-ink;
+$a-link-color: $white;
+$a-box-shadow-color: $brand-granite;


### PR DESCRIPTION
# Overview
- Updates footer link so that Jobs is renamed to "Careers"
- Add new "Go to azavea.com" link
- Added PR template

# Demo
Footer link
![azavea_summer_of_maps_-_home](https://user-images.githubusercontent.com/5672295/45046339-dbb26880-b043-11e8-80a8-75c27587ed81.png)

New "Go to azavea" link
![screen shot 2018-09-04 at 1 03 16 pm](https://user-images.githubusercontent.com/5672295/45046264-a443bc00-b043-11e8-8131-6bfd5447734d.png)
![screen shot 2018-09-04 at 1 03 07 pm](https://user-images.githubusercontent.com/5672295/45046307-c50c1180-b043-11e8-8d33-dc45b0de3d00.png)

# Notes
- The "Go to azavea" link required me to change the design of the header on mobile.
