### PR TITLE
Refactored session logic, cleanup and minor bug fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,13 +15,23 @@ description: >- # this means to ignore newlines until "baseurl:"
 fellowship:
   year: 2019
   timeframe: Summer 2019
-  in_session: false
-  stage:
+  out_of_session:
+    # if summer of maps has ended
+    freeze: true
+    # if summer of maps applications will be going out soon
+    upcoming: false
+  in_session:
+    # if nonprofit/student applications at separate times
     nonprofit_signup: false
     nonprofit_review: false
     student_signup: false
     student_review: false
     student_announcement: false
+    # if nonprofit/student applications at the same times
+    applications_signup: false
+    applications_review: false
+    applications_announcements: false
+    # if students are actively working
     fellowship_ongoing: false
 
 # Student and Non-profit application links
@@ -35,8 +45,8 @@ student_app_link: "https://hire.withgoogle.com/public/jobs/azaveacom/view/P_AAAA
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
-# Estabish project collections
-# Estabish project shortlist collections
+# Establish project collections
+# Establish project shortlist collections
 collections:
   projects:
     output: true

--- a/_config.yml
+++ b/_config.yml
@@ -13,11 +13,11 @@ description: >- # this means to ignore newlines until "baseurl:"
 # What is the stage of the current fellowship?
 # Only assign true to the current stage
 fellowship:
-  year: 2019
-  timeframe: Summer 2019
+  year: 2020
+  timeframe: Summer 2020
   out_of_session:
     # if summer of maps has ended
-    freeze: true
+    freeze: false
     # if summer of maps applications will be going out soon
     upcoming: false
   in_session:
@@ -28,7 +28,7 @@ fellowship:
     student_review: false
     student_announcement: false
     # if nonprofit/student applications at the same times
-    applications_signup: false
+    applications_signup: true
     applications_review: false
     applications_announcements: false
     # if students are actively working
@@ -36,8 +36,8 @@ fellowship:
 
 # Student and Non-profit application links
 # Define where the applications live
-nonprofit_app_link: "https://azavea.forms.fm/2019-summer-of-maps-nonprofit-application"
-student_app_link: "https://hire.withgoogle.com/public/jobs/azaveacom/view/P_AAAAAADAABpPLsAwKiJmIa"
+nonprofit_app_link: "https://azavea.forms.fm/2020-summer-of-maps-nonprofit-application/forms/7494"
+student_app_link: "https://hire.withgoogle.com/public/jobs/azaveacom/view/P_AAAAAADAABpIvUZ6MpUYe-"
 
 ####
 ## DON'T EDIT BEYOND THIS LINE

--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -1,8 +1,6 @@
-- name: Esther Needham
-  shortName: Esther
-  profile: https://www.azavea.com/about/teammate/esther-needham/
-  image: needham.jpg
 - name: Daniel McGlone
   shortName: Daniel
   profile: https://www.azavea.com/about/teammate/daniel-mcglone/
   image: mcglone.jpg
+  bio: >-
+    Daniel is a Senior GIS Analyst and Technical Lead on the Data Analytics Team and Cicero Data Manager. He supports cartography and analysis projects as well as Cicero research and data entry.

--- a/_includes/_global-variables.html
+++ b/_includes/_global-variables.html
@@ -1,0 +1,11 @@
+{% comment %}
+  Logic for determining if in session.
+  1: Assigns output of site.fellowship.in_session to a new variable as a string
+  2: Search new variable for true statement
+  3: Assigns a boolean to variable
+{% endcomment %}
+  {% assign GlobalSessionToString = site.fellowship.in_session | downcase %}
+
+  {% if GlobalSessionToString contains 'true'%}
+    {% assign GlobalInSession = true %}
+  {% endif %}

--- a/_includes/_home/_mentors.html
+++ b/_includes/_home/_mentors.html
@@ -14,13 +14,14 @@
     <div class="mentor-list">
       {% for mentor in site.data.mentors %}
         <div class="mentor">
-          <a href="{{ mentor.profile }}" class="mentor-image" title="{{ mentor.name }}">
-            <img src="assets/images/mentors/{{ mentor.image }}" class="avatar" alt="{{ mentor.name }}">
-          </a>
-          <div class="mentor-name">{{ mentor.name }}</div>
-          <a href="{{ mentor.profile }}" class="mentor-profile" title="{{ mentor.name }}" tabindex="-1">
-            <img src="{{ site.baseurl }}/assets/icons/icon-external-link.svg" alt="external link icon"></img> Meet {{ mentor.shortName }}
-          </a>
+          <img src="assets/images/mentors/{{ mentor.image }}" class="avatar" alt="{{ mentor.name }}">
+          <div class="mentor-info">
+            <div class="mentor-name h4">{{ mentor.name }}</div>
+            <div class="mentor-bio">{{ mentor.bio }}</div>
+            <a href="{{ mentor.profile }}" class="mentor-profile" title="{{ mentor.name }}">
+              <img src="{{ site.baseurl }}/assets/icons/icon-external-link.svg" alt="external link icon"></img> Meet {{ mentor.shortName }}
+            </a>
+          </div>
         </div>
       {% endfor %}
     </div>

--- a/_includes/_project-archives/_projects.html
+++ b/_includes/_project-archives/_projects.html
@@ -1,9 +1,3 @@
-<div class="content-header">
-  <h2 class="content-title">
-    All projects
-  </h2>
-</div>
-
 {% comment %} Group projects by year. {% endcomment %}
 {% assign projects_grouped = site.projects | group_by: 'year' | reverse %}
 {% comment %}

--- a/_includes/_projects/project.html
+++ b/_includes/_projects/project.html
@@ -1,5 +1,7 @@
+{%- include _global-variables.html -%}
+
 {% capture shortlist %}
-  {% if site.fellowship.in_session %}
+  {% if GlobalInSession %}
     <!-- project page intro -->
     {% include {{ page.partials_location }}_intro.html %}
     <!-- project page intro -->
@@ -17,22 +19,11 @@
 {% endcapture %}
 
 {% capture spacer %}
-  {% if site.fellowship.in_session %}
+  {% if GlobalInSession %}
     <div class="section-spacer"></div>
   {% endif %}
 {% endcapture %}
 
-{% if site.fellowship.stage.student_review or
-      site.fellowship.stage.fellowship_ongoing  %}
-
-  {{ project-grid }}
-  {{ spacer }}
-  {{ shortlist }}
-
-{% else %}
-
-  {{ shortlist }}
-  {{ spacer }}
-  {{ project-grid }}
-
-{% endif %}
+{{ project-grid }}
+{{ spacer }}
+{{ shortlist }}

--- a/_includes/call-to-action.html
+++ b/_includes/call-to-action.html
@@ -1,49 +1,94 @@
-<section class="join-us">
+{%- include _global-variables.html -%}
+
+<section class="join-us" id="join-us">
   <div class="container">
     <div class="inner-content">
       <div class="content-header">
         <span class="content-subtitle">
-          {% if site.fellowship.in_session %}
-            {% if site.fellowship.stage.fellowship_ongoing %}
+          {% if GlobalInSession %}
+            {% if site.fellowship.in_session.fellowship_ongoing %}
               Thank you
-            {% elsif site.fellowship.stage.student_announcement %}
+            {% elsif site.fellowship.in_session.student_announcement %}
               Congrats
             {% else %}
               Join us
             {% endif %}
+          {% elsif site.fellowship.out_of_session.upcoming %}
+            Check back soon
           {% else %}
-          Until next time
+            Until next time
           {% endif %}
         </span>
         <h2 class="content-title">
-          {% if site.fellowship.in_session %}
-            {% if site.fellowship.stage.fellowship_ongoing %}
+          {% if GlobalInSession %}
+            {% if site.fellowship.in_session.fellowship_ongoing %}
               The current session is underway
-            {% elsif site.fellowship.stage.student_announcement %}
+            {% elsif site.fellowship.in_session.student_announcement %}
               New fellows announced
             {% else %}
               {{ site.fellowship.timeframe }}
             {% endif %}
+          {% elsif site.fellowship.out_of_session.upcoming %}
+            We're ramping up for {{ site.fellowship.year | plus: 1 }}
           {% else %}
             {{ site.fellowship.timeframe }} session is closed
           {% endif %}
         </h2>
       </div>
       <p class="content-blurb">
-        {% if site.fellowship.in_session %}
-          {% if site.fellowship.stage.nonprofit_signup %}
-            Nonprofit applications for {{ site.fellowship.timeframe }} are open. Apply for a Geospatial Data Analysis Services Grant today!
-          {% elsif site.fellowship.stage.nonprofit_review %}
-            We are currently reviewing nonprofit applications. Fellowship applications for {{ site.fellowship.timeframe }} will open soon.
-          {% elsif site.fellowship.stage.student_signup %}
-            Fellowship applications for {{ site.fellowship.timeframe }} are open. Apply for a paid fellowship position and work on high impact nonprofit projects!
-          {% elsif site.fellowship.stage.student_review %}
+        {% if GlobalInSession %}
+          {% comment %}
+            <!-- Both Org/Student applications sign up -->
+          {% endcomment %}
+          {% if site.fellowship.in_session.applications_signup %}
+            Organization and student applications for {{ site.fellowship.timeframe }} are open. Apply to be a part of Summer of Maps today!
+
+          {% comment %}
+            <!-- Both Org/Student applications review -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.applications_review %}
             Applications for the {{ site.fellowship.timeframe }} session of the Azavea Summer of Maps fellowship program are now closed.
-          {% elsif site.fellowship.stage.student_announcement %}
+
+          {% comment %}
+            <!-- Non profit applications sign up only -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.nonprofit_signup %}
+            Nonprofit applications for {{ site.fellowship.timeframe }} are open. Apply for a Geospatial Data Analysis Services Grant today!
+
+          {% comment %}
+            <!-- Non profit applications review only -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.nonprofit_review %}
+            We are currently reviewing nonprofit applications. Fellowship applications for {{ site.fellowship.timeframe }} will open soon.
+
+          {% comment %}
+            <!-- Student applications sign up only -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.student_signup %}
+            Fellowship applications for {{ site.fellowship.timeframe }} are open. Apply for a paid fellowship position and work on high impact nonprofit projects!
+
+          {% comment %}
+            <!-- Student applications review only -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.student_review %}
+            Applications for the {{ site.fellowship.timeframe }} session of the Azavea Summer of Maps fellowship program are now closed.
+
+          {% comment %}
+            <!-- Student/Org announcement -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.student_announcement or 
+             site.fellowship.in_session.applications_announcements 
+          %}
             The students for the {{ site.fellowship.timeframe }} Azavea Summer of Maps have been <a href="https://www.azavea.com/announcements/summer-of-maps-fellows-and-projects-2019/">announced</a>. Their fellowship will begin shortly.
-          {% elsif site.fellowship.stage.fellowship_ongoing %}
+
+          {% comment %}
+            <!-- Fellowship in progress -->
+          {% endcomment %}
+          {% elsif site.fellowship.in_session.fellowship_ongoing %}
             <a href="/contact/">Sign up</a> for notifications about future opportunities and don't forget to check out the <a href="/projects">projects</a> page for nonprofit projects completed by fellows.
           {% endif %}
+        {% elsif site.fellowship.out_of_session.upcoming %}
+          The {{ site.fellowship.year | plus: 1 }} session is nearly upon us and that means applications will be opening up soon.
         {% else %}
           The {{ site.fellowship.timeframe }} session has finished. <a href="/contact/">Sign up</a> for notifications about future opportunities.
         {% endif %}
@@ -51,26 +96,64 @@
     </div>
     <div class="row align-center">
       <div class="column-10">
-        {% if site.fellowship.in_session %}
+        {% if GlobalInSession %}
         <div class="call-to-action">
           <div class="c2a-image"></div>
           <div class="c2a-message">
-            {% if site.fellowship.stage.nonprofit_signup %}
+            {% comment %}
+              <!-- Both Org/Student applications sign up -->
+            {% endcomment %}
+            {% if site.fellowship.in_session.applications_signup %}
+              <h2>Applications are open until {{ site.data.dates[1].date }}.</h2>
+              <a href="{{ site.nonprofit_app_link }}" class="btn btn-ghost-primary">Nonprofits Apply</a>
+              <a href="{{ site.student_app_link }}" class="btn btn-ghost-primary">Students Apply</a>
+
+            {% comment %}
+              <!-- Both Org/Student applications review -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.applications_review %}
+              <h2>Thank you!</h2>
+              <h3>Applications are now closed and under review. The fellowship will begin shortly.</h3>
+
+            {% comment %}
+              <!-- Non profit applications sign up only -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.nonprofit_signup %}
               <h2>Nonprofit applications are open until {{ site.data.dates[1].date }}.</h2>
               <a href="{{ site.nonprofit_app_link }}" class="btn btn-ghost-primary">Apply now</a>
-            {% elsif site.fellowship.stage.nonprofit_review %}
+
+            {% comment %}
+              <!-- Non profit applications review only -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.nonprofit_review %}
               <h2>Nonprofit applications have closed.</h2>
-              <h3>Check back soon for Fellowship applications.</h3>
-            {% elsif site.fellowship.stage.student_signup %}
-              <h2>Fellow applications are open until {{ site.data.dates[3].date }}.</h2>
+              <h3>Check back soon for student applications.</h3>
+            
+            {% comment %}
+              <!-- Student applications sign up only -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.student_signup %}
+              <h2>Student applications are open until {{ site.data.dates[3].date }}.</h2>
               <a href="{{ site.student_app_link }}" class="btn btn-ghost-primary">Apply now</a>
-            {% elsif site.fellowship.stage.student_review %}
+            
+            {% comment %}
+              <!-- Student applications review only -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.student_review %}
               <h2>Thank you!</h2>
               <h3>Student applications are now closed and under review. The fellowship will begin shortly.</h3>
-            {% elsif site.fellowship.stage.student_announcement %}
+            
+            {% comment %}
+              <!-- Student/Org announcement -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.student_announcement or site.fellowship.in_session.applications_announcements  %}
               <h2>Congratulations {{ site.fellowship.year }} fellows</h2>
               <h3>Summer of Maps Fellows will begin their fellowships shortly.</h3>
-            {% elsif site.fellowship.stage.fellowship_ongoing %}
+            
+            {% comment %}
+              <!-- Fellowship in progress -->
+            {% endcomment %}
+            {% elsif site.fellowship.in_session.fellowship_ongoing %}
               <h2>Congratulations {{ site.fellowship.year }} fellows</h2>
               <h3>Summer of Maps Fellows are hard at work on challenging, high impact projects.</h3>
             {% endif %}

--- a/_includes/call-to-action.html
+++ b/_includes/call-to-action.html
@@ -41,7 +41,7 @@
             <!-- Both Org/Student applications sign up -->
           {% endcomment %}
           {% if site.fellowship.in_session.applications_signup %}
-            Organization and student applications for {{ site.fellowship.timeframe }} are open. Apply to be a part of Summer of Maps today!
+            Nonprofit and student applications for {{ site.fellowship.timeframe }} are open. Apply to be a part of Summer of Maps today!
 
           {% comment %}
             <!-- Both Org/Student applications review -->
@@ -105,8 +105,8 @@
             {% endcomment %}
             {% if site.fellowship.in_session.applications_signup %}
               <h2>Applications are open until {{ site.data.dates[1].date }}.</h2>
-              <a href="{{ site.nonprofit_app_link }}" class="btn btn-ghost-primary">Nonprofits Apply</a>
-              <a href="{{ site.student_app_link }}" class="btn btn-ghost-primary">Students Apply</a>
+              <a href="{{ site.nonprofit_app_link }}" class="btn btn-ghost-primary">Nonprofits apply</a>
+              <a href="{{ site.student_app_link }}" class="btn btn-ghost-primary">Students apply</a>
 
             {% comment %}
               <!-- Both Org/Student applications review -->

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,12 +9,10 @@
         <a href="/projects">Projects</a>
         <a href="/faq">FAQ</a>
         <a href="/contact">Contact</a>
-        {% if site.fellowship.in_session %}
-          {% if site.fellowship.stage.nonprofit_signup %}
-          <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
-          {% elsif site.fellowship.stage.student_signup %}
-          <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
-          {% endif %}
+        {% if site.fellowship.in_session.nonprofit_signup %}
+        <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
+        {% elsif site.fellowship.in_session.student_signup %}
+        <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
         {% endif %}
       </nav>
     </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,9 +10,9 @@
         <a href="/faq">FAQ</a>
         <a href="/contact">Contact</a>
         {% if site.fellowship.in_session.nonprofit_signup %}
-        <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
+        <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits apply</a>
         {% elsif site.fellowship.in_session.student_signup %}
-        <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
+        <a href="{{ site.student_app_link}}" class="btn btn-primary">Students apply</a>
         {% endif %}
       </nav>
     </div>

--- a/_includes/hero-post.html
+++ b/_includes/hero-post.html
@@ -12,9 +12,6 @@
       {% if page.secondary-title %}
         <div class="hero-secondary-title">{{ page.secondary-title }}</div>
       {% endif %}
-      {% if site.fellowship_in_session %}
-        <a href="#" class="btn btn-primary">Apply</a>
-      {% endif %}
     </div>
   </div>
 </header>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -14,12 +14,12 @@
       <div class="hero-actions">
         {% if GlobalInSession %}
           {% if site.fellowship.in_session.nonprofit_signup %}
-          <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
+          <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits apply</a>
           {% elsif site.fellowship.in_session.student_signup %}
-          <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
+          <a href="{{ site.student_app_link}}" class="btn btn-primary">Students apply</a>
           {% elsif site.fellowship.in_session.applications_signup %}
-          <a href="{{ site.nonprofit_app_link}}" class="btn btn-ghost-secondary">Nonprofits Apply</a>
-          <a href="{{ site.student_app_link}}" class="btn btn-ghost-secondary">Students Apply</a>
+          <a href="{{ site.nonprofit_app_link}}" class="btn btn-ghost-secondary">Nonprofits apply</a>
+          <a href="{{ site.student_app_link}}" class="btn btn-ghost-secondary">Students apply</a>
           {% endif %}
         {% else %}
           <a href="#job-alert-modal" class="btn btn-ghost-secondary form-modal-open" rel="modal:open">

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,3 +1,5 @@
+{%- include _global-variables.html -%}
+
 <header class="hero" id="hero">
   {% if page.no_hero != true %}
   <div class="container">
@@ -10,11 +12,14 @@
       </h2>
 
       <div class="hero-actions">
-        {% if site.fellowship.in_session %}
-          {% if site.fellowship.stage.nonprofit_signup %}
+        {% if GlobalInSession %}
+          {% if site.fellowship.in_session.nonprofit_signup %}
           <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
-          {% elsif site.fellowship.stage.student_signup %}
+          {% elsif site.fellowship.in_session.student_signup %}
           <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
+          {% elsif site.fellowship.in_session.applications_signup %}
+          <a href="{{ site.nonprofit_app_link}}" class="btn btn-ghost-secondary">Nonprofits Apply</a>
+          <a href="{{ site.student_app_link}}" class="btn btn-ghost-secondary">Students Apply</a>
           {% endif %}
         {% else %}
           <a href="#job-alert-modal" class="btn btn-ghost-secondary form-modal-open" rel="modal:open">
@@ -25,14 +30,14 @@
       </div>
     </div>
     <div class="hero-viz">
-      <img src="../assets/images/philly-map.jpg" alt="" class="hero-viz-map">
-      <img src="../assets/images/philly-counties-yellow.svg" alt="" class="hero-viz-counties-shapes">
-      <img src="../assets/images/philly-counties-lite-green.svg" alt="" class="hero-viz-counties-shapes">
-      <img src="../assets/images/philly-counties-lame-green.svg" alt="" class="hero-viz-counties-shapes">
-      <img src="../assets/images/philly-counties-teal.svg" alt="" class="hero-viz-counties-shapes">
-      <img src="../assets/images/philly-counties-sky-blue.svg" alt="" class="hero-viz-counties-shapes">
-      <img src="../assets/images/philly-counties-blue.svg" alt="" class="hero-viz-counties-shapes">
-      <img src="../assets/images/philly-counties-dark-blue.svg" alt="" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-map.jpg" alt="" role="presentation" class="hero-viz-map">
+      <img src="../assets/images/philly-counties-yellow.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-counties-lite-green.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-counties-lame-green.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-counties-teal.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-counties-sky-blue.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-counties-blue.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
+      <img src="../assets/images/philly-counties-dark-blue.svg" alt="" role="presentation" class="hero-viz-counties-shapes">
     </div>
   </div>
   {% endif %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -31,12 +31,12 @@
           {% endif %}>
           Contact
         </a>
-        {% if site.fellowship.in_session %}
-          {% if site.fellowship.stage.nonprofit_signup %}
-          <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
-          {% elsif site.fellowship.stage.student_signup %}
-          <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
-          {% endif %}
+        {% if site.fellowship.in_session.nonprofit_signup %}
+        <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
+        {% elsif site.fellowship.in_session.student_signup %}
+        <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
+        {% elsif site.fellowship.in_session.applications_signup %}
+          <a href="#join-us" class="btn btn-ghost-secondary">Apply now</a>
         {% endif %}
       </nav>
     </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -32,9 +32,9 @@
           Contact
         </a>
         {% if site.fellowship.in_session.nonprofit_signup %}
-        <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits Apply</a>
+        <a href="{{ site.nonprofit_app_link}}" class="btn btn-primary">Nonprofits apply</a>
         {% elsif site.fellowship.in_session.student_signup %}
-        <a href="{{ site.student_app_link}}" class="btn btn-primary">Students Apply</a>
+        <a href="{{ site.student_app_link}}" class="btn btn-primary">Students apply</a>
         {% elsif site.fellowship.in_session.applications_signup %}
           <a href="#join-us" class="btn btn-ghost-secondary">Apply now</a>
         {% endif %}

--- a/_includes/shortlist-list.html
+++ b/_includes/shortlist-list.html
@@ -2,8 +2,8 @@
 {% assign categories = shortlist | map: 'category' | uniq %} 
 {% if shortlist.size == 0 %}
 <div class="project-list empty" id="project-list">
-  <div class="empty-message">This year's shortlist hasn't been announced yet. Check back soon.</div>
-  <a class="btn btn-ghost-primary" href="/project/shortlist/{{ site.fellowship.year - 1}}">See last year's project shortlist</a>
+  <div class="empty-message">This year's shortlist hasn't been announced yet.</div>
+  <a class="btn btn-ghost-primary" href="/projects/shortlist/{{ site.fellowship.year | minus: 1}}">See last year's project shortlist</a>
 </div>
 {% else %}
 <div class="project-list" id="project-list">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
   <!-- SEO -->
   <title>{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}</title>
   <meta name="description" content="{% if page.seo_description %}{{ page.seo_description }}{% endif %}">
-  <meta name="Copyright" content="Copyright © Summer of Maps 2019. All Rights Reserved.">
+  <meta name="Copyright" content="Copyright © Summer of Maps 2019-2020. All Rights Reserved.">
 
   <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/favicon/favicon-32x32.png">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,5 @@
+{%- include _global-variables.html -%}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -57,7 +59,7 @@
   {% if page.hide-footer != true %}
     {% include footer.html %}
   {% endif %}
-  {% unless site.fellowship.in_session %}
+  {% unless GlobalInSession %}
     {% include form-modal.html %}
   {% endunless %}
 

--- a/_layouts/secondary.html
+++ b/_layouts/secondary.html
@@ -12,14 +12,14 @@ use-alternate-hero: true
     {% if page.show-webinar %}
       <div class="webinar-c2a">
         <figure class="webinar-video">
-            <iframe width="560" height="315" src="https://www.youtube.com/embed/9vVPUWA_G_o" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-            <figcaption>2018 Summer of Maps webinar</figcaption>
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/GXhnnGNuDqg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <figcaption>2019 Summer of Maps webinar</figcaption>
         </figure>
         <div class="webinar-message" markdown="1">
           <h2>Sign up for our next webinar</h2>
-          <em>Wed, Oct 30, 2019 11:00 AM - 12:00 PM EDT</em>
-          <p>An overview of how to apply to the program and answers to your questions about how to craft geospatial data analysis projects.</p>
-          <a href="https://attendee.gotowebinar.com/register/914449928810323724" class="btn btn-ghost-primary">Join our next webinar</a>
+          <em>Tue, Jan 7, 2020 2:00 PM - 3:00 PM EST</em>
+          <p>An overview of the Summer of Maps program and how you can create a great application followed by a Q&A period if you have questions specific to your application.</p>
+          <a href="https://register.gotowebinar.com/register/8642710453171744781" class="btn btn-ghost-primary">Join our next webinar</a>
           <p>or <a href="/contact/">receive a notice</a> when the applications open</p>
         </div>
       </div>

--- a/_pages/page-home.html
+++ b/_pages/page-home.html
@@ -58,7 +58,6 @@ mentors:
 # Page copy
 # # # # # #
 ---
-
 <!-- Homepage content -->
 {% include {{ page.partials_location }}home.html %}
 <!-- Homepage content -->

--- a/_pages/page-project-all.html
+++ b/_pages/page-project-all.html
@@ -12,8 +12,8 @@ seo_description: ""
 
 # hero section
 hero:
-  above-title: "Completed projects"
-  title: "Project archive"
+  above-title: "Project showcase"
+  title: "Summer of Maps projects"
   subtitle: "Explore projects completed for nonprofits as part of previous Azavea Summer of Maps seasons."
 # hero section
 ---

--- a/_pages/page-projects.html
+++ b/_pages/page-projects.html
@@ -21,10 +21,10 @@ hero:
 
 # page intro section
 intro:
-  above-title: "Proposed Projects"
-  title: "2019 Project shortlist"
+  above-title: "Proposed projects"
+  title: "2020 project shortlist"
   blurb:
-    - Fellows select projects they would like to work on as part of the application process and the top projects are then awarded grants. Select a proposed project to see client goals and more details, or take a look at project shortlists from <a href='/projects/all#previous-shortlist-years'>previous years</a>.
+    - Once the fellowship begins, fellows choose projects they want to work on from the shortlist. Take a look at project shortlists from <a href='/projects/all#previous-shortlist-years'>previous years</a> to see what has been proposed in the past.
 # page intro section
 ---
 <!-- Filter the shortlist by the current year -->

--- a/_sass/components/_call-to-action.scss
+++ b/_sass/components/_call-to-action.scss
@@ -47,7 +47,7 @@ section.join-us {
 }
 
 .c2a-message {
-  padding: 4rem;
+  padding: 3rem;
   flex: 1;
 
   @media (max-width: 900px) {

--- a/_sass/components/_mentor.scss
+++ b/_sass/components/_mentor.scss
@@ -1,40 +1,42 @@
 .mentor-list {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: space-between;
 }
 
 .mentor {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  padding: 1rem 0;
-  flex-basis: 20%;
+  margin: 1rem 0;
+  padding: 2rem;
   display: flex;
-  flex-direction: column;
   align-items: center;
   position: relative;
   font-size: 1.8rem;
+  background: #fff;
+  flex: 1 48%;
+  max-width: 48%;
+
+  .mentor-info {
+    flex: 1;
+    padding: 2rem;
+  }
 
   .avatar {
     border-radius: 100%;
     width: 15rem;
-    max-width: 100%;
+    flex: none;
   }
 
   .mentor-name {
-    transition: .2s ease-in-out opacity;
+    margin-top: 0;
+  }
+
+  .mentor-bio {
+    font-size: 16px;
+    margin: 0px 0 10px;
+    font-style: italic;
   }
 
   .mentor-profile {
-    opacity: 0;
-    position: absolute;
-    bottom: 1rem;
-    left: 50%;
-    transform: translateX(-50%);
-    transition: .2s ease-in-out opacity;
-    user-select: none;
-    white-space: nowrap;
-
     img {
       max-width: 1.2rem;
       margin-right: 5px;
@@ -42,8 +44,12 @@
   }
 
   @media (max-width: 900px) {
-    flex-basis: 33%;
+    flex-direction: column;
     font-size: 1.6rem;
+    text-align: center;
+    flex: none;
+    width: 100%;
+    max-width: 100%;
 
     .avatar {
       max-width: 80%;
@@ -51,21 +57,5 @@
       margin: 0 auto 1rem;
       display: block;
     }
-  }
-
-  @media (max-width: 650px) {
-    flex-basis: 50%;
-  }
-}
-
-.mentor:hover {
-
-  .mentor-name {
-    opacity: 0;
-  }
-  
-  .mentor-profile {
-    opacity: 1;
-    color: $primary;
   }
 }


### PR DESCRIPTION
## Overview

**1: Refactors the logic for how we handle the different stages of Summer of Maps.** 
The new logic maintains all previous functionality plus supporting:
- Multiple out of session stages (previously out of session was a single stage, this opens it up to allow for multiple stages of out of session logic if desired)
    - implements logic for `freeze` and `upcoming`
- Allows for opening both organization and student applications at the same time (previously only allowed for applications to be opened at separate times)
    - `applications_signup`, `applications_review`, `applications_announcements` stages implemented
   - `applications_signup` shows both application signup buttons in call to action and homepage hero and adds a button to the navbar which scrolls the user to the call to action
   - maintains logic for separate application periods

Session logic now looks as follows, where only one of these options should be true at a time:
```
out_of_session:
    freeze: bool
    upcoming: bool
in_session:
    nonprofit_signup: bool
    nonprofit_review: bool
    student_signup: bool
    student_review: bool
    student_announcement: bool
    applications_signup: bool
    applications_review: bool
    applications_announcements: bool
    fellowship_ongoing: bool
```

**2: Added logic to replace basic `in_session: bool` logic**
The new `in_session` combines the old logic of `in_session: bool` + `stage: object`. Jekyll is pretty dumb in it's parsing of YAML. There's no great way to check if a `key:value` within an object is true without crazy looping methods. This would have been a lot of duplication of logic. Instead, I wrote a Jekyll variable `GlobalInSession` within `_includes/_global-variables.html`, to handle checking if any of the `key:values` nested within `in_session` are marked true. This `_global-variables.html` include was then included in files only where it was needed to replace the old `in_session` logic.

**3: Updates the mentor section**
- added mentor bios
- updates to the mentor section design
- removed Esther from mentors

**4: Other changes:**
- Removed logic which rendered the project page in a different order depending on the stage.
- Set `out_of_session.upcoming` to true to reflect the current stage of Summer of Maps
- Removed redundant "All Projects" title from all projects page.
- Removed unused code from `_includes/hero-post.html`
- fixed broken link in `_includes/shortlist-list.html`
- copy updates throughout 


### Demo

I took some screenshots for each stage and how the site is changed:
[summer_of_maps-screenshots.zip](https://github.com/azavea/summer-of-maps-website/files/3842587/summer_of_maps-screenshots.zip)


## Testing Instructions

Testing Summer of Maps is pretty burdensome. You must make sure `./scripts/server` is not running if you make any changes to `_config.yml`. Once you make a change, then spin the server up. Once the server is up and running, open up a `.html` or `.md` file and save it. This will force jekyll to rebuild.

This is how the content changes with each stage:
- `out_of_session.freeze`, `out_of_session.upcoming`, `in_session.nonprofit_review`, `in_session.student_review`, `in_session.student_announcement`, `in_session.applications_review`, `in_session.applications_announcements`, `in_session.fellowship_ongoing`
  - Only affects the call to action messaging
- `in_session.nonprofit_signup`, `in_session.student_signup`
  - Call to action messaging
  - Navbar, Homepage hero and Footer get single apply buttons
- `in_session.applications_signup`
  - Call to action messaging
  - Homepage hero gets two apply buttons for both students and orgs
  - Navbar gets an apply button that scrolls user to call to action section

Closes #74
