### PR TITLE
implements MailChimp integration for contact forms

### DIFF
--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -1,97 +1,78 @@
 <div class="form {{ include.theme }}">
-  <form action="" method="POST" novalidate="novalidate" role="form" id="signup-form">
-    <input type="hidden" name="oid" value="00D30000000efK8">
-    <input type="hidden" name="retURL" value="https://www.summerofmaps.com/thank-you">
-    <input id="Campaign_ID" name="Campaign_ID" type="hidden" value="70130000001uVrF">
-    <input type="hidden" id="member_status" name="member_status" value="">
-    <input type="hidden" id="00N30000004RyN1" name="00N30000004RyN1" value="1">
-    <input type="hidden" id="70130000001uVrF" name="70130000001uVrF" value="1">
-    <input id="description" name="description" type="hidden" value="">
-    <input id="lead_source" name="lead_source" type="hidden" value="Web">
-    <input id="00N30000009Hz7V" name="00N30000009Hz7V" type="hidden" value="MwR6IuFGE6oTIdTFHYgGyYfrkiEUi6w9DN2">
+  <form action="" method="POST" novalidate="novalidate" role="form" class="hs-contact-form"">
     <div class="form-group">
       <label>First Name <span>*</span>
-         <input id="first_name" name="first_name" required="required" type="text">
+         <input name="firstname" required="required" type="text">
       </label>
     </div>
     <div class="form-group">
       <label>Last Name <span>*</span>
-        <input id="last_name" name="last_name" required="required" type="text">
+        <input name="lastname" required="required" type="text">
       </label>
     </div>
     <div class="form-group">
       <label>Email <span>*</span>
-        <input id="email" name="email" type="email" required="required" type="email">
+        <input name="email" type="email" required="required" type="email">
       </label>
     </div>
     <div class="form-group">
       <label>Phone
-        <input id="phone" name="phone" type="tel">
+        <input name="phone" type="tel">
       </label>
     </div>
     <div class="form-group">
       <label>Organization
-        <input id="company" name="company"  type="text">
+        <input name="company"  type="text">
       </label>
     </div>
     <div class="form-group radio-list">
       <label>I'm interested in becoming a:</label>
       <label class="radio">
-        <input type="radio" name="involvementType" id="involvementType1" value="701a0000002AIuA">
+        <input type="radio" name="som_interest" value="fellow">
         <span></span>
         fellow
       </label>
       <label class="radio">
-        <input type="radio" name="involvementType" id="involvementType2" value="701a0000002AIuP">
+        <input type="radio" name="som_interest" value="mentor">
         <span></span>
         mentor
       </label>
       <label class="radio">
-        <input type="radio" name="involvementType" id="involvementType3" value="701a0000002AIuF">
+        <input type="radio" name="som_interest" value="participating nonprofit">
         <span></span>
         participating nonprofit
       </label>
       <label class="radio">
-        <input type="radio" name="involvementType" id="involvementType4" value="701a0000002AIuK">
+        <input type="radio" name="som_interest" value="sponsor">
         <span></span>
         sponsor
       </label>
     </div>
     <div class="form-group full-width">
       <label>Message
-        <textarea id="description" name="description"></textarea>
+        <textarea name="message"></textarea>
       </label>
     </div>
     <div class="contact-method">
-      <label class="just-checking">Leave the following fields empty/unchecked</label>
+      <label class="just-checking" aria-hidden="true">Leave the following fields empty/unchecked</label>
       <input 
         type="text" 
-        class="just-checking" 
-        id="contact-method-official-name-of-org"
-        name="contact-method-official-name-of-org"
-        tabindex="-1" 
-        autocomplete="off"
-        aria-hidden="true">
-      <input 
-        type="checkbox" 
-        name="contact-by-phone-only" 
-        id="contact-by-phone-only" 
-        value="1" 
-        class="just-checking"
+        class="just-checking contact-method-fullname"
+        name="contact-method-fullname"
         tabindex="-1" 
         autocomplete="off"
         aria-hidden="true">
       <input 
         type="text" 
-        class="just-checking" 
-        id="contact-method-phone"
+        class="just-checking contact-method-phone" 
         name="contact-method-phone"
         tabindex="-1" 
         autocomplete="off"
         aria-hidden="true">
     </div>
+    <input name="hs_context" class="hs_context" type="hidden" value="">
     <div class="form-action">
-      <button disabled type="submit" class="btn {{include.submit}}" id="contact-form-submit">Get in Touch</button>
+      <input type="submit" value="Submit" class="btn {{include.submit}} contact-form-submit" disabled>
     </div>
   </form>
 </div>

--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -1,56 +1,56 @@
 <div class="form {{ include.theme }}">
-  <form action="" method="POST" novalidate="novalidate" role="form" class="hs-contact-form"">
+  <form action="" method="POST" novalidate="novalidate" role="form" class="contact-form"">
     <div class="form-group">
       <label>First Name <span>*</span>
-         <input name="firstname" required="required" type="text">
+         <input name="FNAME" required="required" type="text">
       </label>
     </div>
     <div class="form-group">
       <label>Last Name <span>*</span>
-        <input name="lastname" required="required" type="text">
+        <input name="LNAME" required="required" type="text">
       </label>
     </div>
     <div class="form-group">
       <label>Email <span>*</span>
-        <input name="email" type="email" required="required" type="email">
+        <input name="EMAIL" type="email" required="required">
       </label>
     </div>
     <div class="form-group">
       <label>Phone
-        <input name="phone" type="tel">
+        <input name="PHONE" type="tel">
       </label>
     </div>
     <div class="form-group">
       <label>Organization
-        <input name="company"  type="text">
+        <input name="COMPANY" type="text">
       </label>
     </div>
     <div class="form-group radio-list">
       <label>I'm interested in becoming a:</label>
       <label class="radio">
-        <input type="radio" name="som_interest" value="fellow">
+        <input type="radio" name="INTEREST" value="Fellow">
         <span></span>
-        fellow
+        Fellow
       </label>
       <label class="radio">
-        <input type="radio" name="som_interest" value="mentor">
+        <input type="radio" name="INTEREST" value="Mentor">
         <span></span>
-        mentor
+        Mentor
       </label>
       <label class="radio">
-        <input type="radio" name="som_interest" value="participating nonprofit">
+        <input type="radio" name="INTEREST" value="Participating nonprofit">
         <span></span>
-        participating nonprofit
+        Participating nonprofit
       </label>
       <label class="radio">
-        <input type="radio" name="som_interest" value="sponsor">
+        <input type="radio" name="INTEREST" value="Sponsor">
         <span></span>
-        sponsor
+        Sponsor
       </label>
     </div>
     <div class="form-group full-width">
       <label>Message
-        <textarea name="message"></textarea>
+        <textarea name="MESSAGE"></textarea>
       </label>
     </div>
     <div class="contact-method">
@@ -70,7 +70,6 @@
         autocomplete="off"
         aria-hidden="true">
     </div>
-    <input name="hs_context" class="hs_context" type="hidden" value="">
     <div class="form-action">
       <input type="submit" value="Submit" class="btn {{include.submit}} contact-form-submit" disabled>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,8 +30,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.css" />
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700|Source+Code+Pro" rel="stylesheet">
-
-  
+  <!-- Start of HubSpot Embed Code -->
+  <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/6397011.js"></script>
+  <!-- End of HubSpot Embed Code -->
 </head>
 <body 
   {% if page.page_class %} 
@@ -64,47 +65,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js"></script>
   <script src="/assets/javascript/pristine.js"></script>
-  <script>
-    /* 
-    ** Basic Front-end spam prevention techniques in use: 
-    ** Technique 1: Only enable form submission 3.5 seconds after page load
-    ** Technique 2: Basic form validation using Pristine.js
-    ** Technique 3: Three honeypot field checks https://stackoverflow.com/questions/36227376/better-honeypot-implementation-form-anti-spam
-    */
-    window.onload = function () {
-      var hpValid = true;
-      var form = document.getElementById("signup-form");
-      var formAction = "https://webto.salesforce.com/servlet/servlet.WebToLead"
-      var submitButton = document.getElementById("contact-form-submit");
-      var pristine = new Pristine(form);
-      
-      // Technique 1
-      setTimeout(function() {
-        submitButton.disabled = false;
-        form.action = formAction;
-      }, 3500);
-
-      // Technique 2 & 3
-      form.addEventListener('submit', function (e) {
-        e.preventDefault();
-
-        var hpFields = {
-          1: document.getElementById("contact-method-official-name-of-org"),
-          2: document.getElementById("contact-method-phone"),
-          3: document.getElementById("contact-by-phone-only")
-        }
-
-        // check if the form is valid and honeypots are unchanged
-        if (hpFields[1].value.length != 0 ||
-            hpFields[2].value.length != 0 ||
-            hpFields[3].checked) {
-          hpValid = false;
-        };
-        var checkValidity = pristine.validate();
-        if( checkValidity && hpValid ) { form.submit() }
-      });
-    };
-  </script>
+  <script src="/assets/javascript/contact-form-handler.js"></script>
   {% if page.js_dependencies %}
     {% for dependency in page.js_dependencies %}
     <script src="{{ site.baseurl }}/assets/javascript/{{ dependency }}"></script>

--- a/_sass/components/_form.scss
+++ b/_sass/components/_form.scss
@@ -211,6 +211,8 @@ label {
   width: initial !important;
   border: initial !important;
   padding: initial !important;
+  margin: 0 !important;
+  font-size: 0!important;
 }
 
 input[type="checkbox"].just-checking {

--- a/assets/javascript/contact-form-handler.js
+++ b/assets/javascript/contact-form-handler.js
@@ -1,3 +1,7 @@
+---
+# Front matter comment to ensure Jekyll properly reads file.
+---
+
 /* Grab the users ip for Hubspot */
 var userIP;
 function getUserIp() {

--- a/assets/javascript/contact-form-handler.js
+++ b/assets/javascript/contact-form-handler.js
@@ -1,0 +1,86 @@
+/* Grab the users ip for Hubspot */
+var userIP;
+function getUserIp() {
+  $.getJSON('https://api.ipify.org?format=jsonp&callback=?')
+    .fail(function(json) {  
+      userIP = '';
+    })  
+    .done(function(json) {  
+      userIP = json.ip
+    });
+}
+
+/* Cookie parsing function used by Hubspot context */
+function getCookie(name) {
+  var cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = jQuery.trim(cookies[i]);
+      if (cookie.substring(0, name.length + 1) == (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+
+$(function() {
+  var hpValid = true;
+  var $formEls = $(".hs-contact-form");
+  var $submitButton = $(".contact-form-submit");
+  var hsContextInput = $(".hs_context");
+  var redirectUrl = "https://www.summerofmaps.com/thank-you/";
+  var formEndpoint = "https://forms.hubspot.com/uploads/form/v2/6397011/93b85556-046d-44fe-91c5-c2942c27a629";
+
+  getUserIp();
+
+  function setHSContext() {
+    var hs_context = {
+      hutk: getCookie('hubspotutk') || '',
+      ipAddress: userIP,
+      pageUrl: window.location.href,
+      pageName: document.title,
+      redirectUrl: redirectUrl
+    }
+    return JSON.stringify(hs_context);
+  }
+
+  // Delay submitting immediately
+  // Set Hubspot context value
+  setTimeout(function() {
+    $(hsContextInput).each(function() {
+      $(this).val(setHSContext());
+    });
+    $submitButton.each(function() {
+      $(this).attr("disabled", false);
+    });
+    $($formEls).each(function() {
+      $(this).attr("action", formEndpoint);
+    });
+  }, 3500);
+
+  // For each form make sure we run client-side validation
+  $($formEls).each( function() {
+    var pristine = new Pristine(this);
+    
+    $(this).on('submit', function (e) {
+      e.preventDefault();
+      
+      var hpFields_1 = $(".contact-method-fullname"),
+          hpFields_2 = $(".contact-method-phone");
+      
+      if ($(hpFields_1).val() || $(hpFields_2).val()) {
+        hpValid = false;
+        console.log(hpValid)
+      } else {
+        hpValid = true;
+        console.log(hpValid)
+      };
+
+      var checkValidity = pristine.validate();
+      if( checkValidity && hpValid ) { this.submit() };
+   });
+  });
+});

--- a/assets/javascript/contact-form-handler.js
+++ b/assets/javascript/contact-form-handler.js
@@ -2,61 +2,15 @@
 # Front matter comment to ensure Jekyll properly reads file.
 ---
 
-/* Grab the users ip for Hubspot */
-var userIP;
-function getUserIp() {
-  $.getJSON('https://api.ipify.org?format=jsonp&callback=?')
-    .fail(function(json) {  
-      userIP = '';
-    })  
-    .done(function(json) {  
-      userIP = json.ip
-    });
-}
-
-/* Cookie parsing function used by Hubspot context */
-function getCookie(name) {
-  var cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    var cookies = document.cookie.split(';');
-    for (var i = 0; i < cookies.length; i++) {
-      var cookie = jQuery.trim(cookies[i]);
-      if (cookie.substring(0, name.length + 1) == (name + '=')) {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
-}
-
 $(function() {
   var hpValid = true;
-  var $formEls = $(".hs-contact-form");
+  var $formEls = $(".contact-form");
   var $submitButton = $(".contact-form-submit");
-  var hsContextInput = $(".hs_context");
-  var redirectUrl = "https://www.summerofmaps.com/thank-you/";
-  var formEndpoint = "https://forms.hubspot.com/uploads/form/v2/6397011/93b85556-046d-44fe-91c5-c2942c27a629";
-
-  getUserIp();
-
-  function setHSContext() {
-    var hs_context = {
-      hutk: getCookie('hubspotutk') || '',
-      ipAddress: userIP,
-      pageUrl: window.location.href,
-      pageName: document.title,
-      redirectUrl: redirectUrl
-    }
-    return JSON.stringify(hs_context);
-  }
+  var formEndpoint = "https://azavea.us1.list-manage.com/subscribe/post?u=61da999c9897859f1c1fff262&amp;id=d3663223c9";
 
   // Delay submitting immediately
   // Set Hubspot context value
   setTimeout(function() {
-    $(hsContextInput).each(function() {
-      $(this).val(setHSContext());
-    });
     $submitButton.each(function() {
       $(this).attr("disabled", false);
     });


### PR DESCRIPTION
**Overview**
- Updated the logic on the contact forms to submit to ~HubSpot~ MailChimp instead of Salesforce
- Maintains the various spam prevention techniques (small tweaks to code)
    - PristineJS for client-side validation
    - Honeypot inputs for bots
    - Prevent form submission for 3.5 seconds

**Testing:**

- spin up the vm and server
- go to `/contact`
- Try hitting submit immediately (shouldnt work for 3.5 second)
- Try submitting without entering any inputs (client-side validation should kick in)
- Fill in the missing inputs (The errors should go away as you fix the input errors)
- Inspect the form and remove the css which hides the honeypot inputs classname = `.just-checking`.
- Enter something into either of the honeypot inputs.
- Try submitting the form (it shouldn't do anything)
- Remove any values you entered in the honeypots and submit. (You should be redirected to the mailchimp summer of maps confirmation page)