### PR TITLE
Edit hiatus text to focus on 2021

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,7 +41,7 @@
     class="{{- page.page_class }} {{ layout.page_class -}}" 
   {% endif %}>
   <div class="banner">
-    <h4>Summer of maps has been postponed until 2022</h4> 
+    <h4>Summer of Maps will be on hiatus in 2021</h4>
     <p>If you have questions please <a href="{{ site.baseurl }}/contact">contact us</a></p>
   </div>
   {% include navbar.html %}


### PR DESCRIPTION
## Overview
Updates the hiatus text so that it doesn't imply anything about 2022. 

### Demo
<img width="1414" alt="Screen Shot 2020-12-21 at 9 29 14 AM" src="https://user-images.githubusercontent.com/5672295/102742727-09379300-436f-11eb-82e7-d6dddd7b13ea.png">

fyi @designmatty 

Connects https://github.com/azavea/summer-of-maps-website/pull/90
